### PR TITLE
Adds 'rails db:setup' command to installation steps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ rvm: https://rvm.io/rvm/install
 3. `cd drc-pg-workshop`
 4. Check Ruby version: `ruby -v` should show `2.4.1`
 5. `bundle install`
+6. `rails db:setup` for creating databases and running migrations
 
 ## Test if everything is working
 `./bin/rake` should work without errors, if it does, you're all set.


### PR DESCRIPTION
Noticed that running `./bin/rake` failed if databases were not created.
So I've added a step in the README for running `rails db:setup`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/swanandp/drc-pg-workshop/2)
<!-- Reviewable:end -->
